### PR TITLE
don't compare timezone when checking meeting times

### DIFF
--- a/lambda/src/main/scala/com/gu/meeting/ReminderHandler.scala
+++ b/lambda/src/main/scala/com/gu/meeting/ReminderHandler.scala
@@ -24,7 +24,7 @@ object LocalTest {
   // this main method is useful to try it locally
   @main
   def runTest() = {
-    val lambdaWarmStartTime = OffsetDateTime.parse("2025-02-13T12:30:12.123Z")
+    val lambdaWarmStartTime = OffsetDateTime.parse("2025-04-25T09:45:12.123+01:00")
     val googleServiceEmail = config.getString("google-service-email")
     ReminderHandlerSteps.runSteps(googleServiceEmail, calendar, lambdaWarmStartTime, HttpClient.newHttpClient)
   }

--- a/lambda/src/main/scala/com/gu/meeting/ReminderHandlerSteps.scala
+++ b/lambda/src/main/scala/com/gu/meeting/ReminderHandlerSteps.scala
@@ -75,7 +75,8 @@ object MeetingData extends StrictLogging {
       for {
         event <- eventsList
         meeting <- MeetingData.fromApiEvent(event)
-        if minuteOfInterest == meeting.start
+        _ = logger.info(s"comparing minute of interest ${minuteOfInterest.toInstant} with ${meeting.start.toInstant}")
+        if minuteOfInterest.toInstant == meeting.start.toInstant
         _ = logger.info("Sending message for meeting " + meeting)
         chatMessage = {
           val link = meeting.meetLink match {


### PR DESCRIPTION
Previously the code was comparing OffsetDateTimes when filtering if the meeting is about to start.
This was working when the calendar was returning the meetings in UTC as the "now" was also coming back as UTC.

Since https://github.com/guardian/meeting-reminder-bot/pull/5 where I changed it so the calendar returns in london time, since it's BST at the moment, it was thinking the times were different at the point when the meeting started, thus not notifying.

This PR makes it compare the Instant (which is timezone agnostic) instead of the whole date time including timezone.

Tested locally and works fine.