### PR TITLE
Only allow guardian org members to trigger the bot

### DIFF
--- a/.github/workflows/ci-scala.yml
+++ b/.github/workflows/ci-scala.yml
@@ -37,7 +37,7 @@ jobs:
       - name: Run tests and build JAR
         run: sbt test lambda/assembly
 
-      - name: Create CFN from CDK (TODO CDK tests)
+      - name: Create CFN from CDK
         run: cdk synth --app "sbt test 'cdk/runMain com.gu.meeting.main'"
 
       - name: Upload to Riff-Raff

--- a/README.md
+++ b/README.md
@@ -6,8 +6,8 @@ Follow these two steps:
 1. Add a suitable chat webhook to your chat channel (or use an existing one)
 <img width="582" alt="image" src="https://github.com/user-attachments/assets/1a956173-0f52-4fd6-9e8a-d794c34ee23d" />
 
-2. Paste the URL into your meeting description somewhere, and invite the special bot to your meeting.  Ask John for the service account address (it's private to avoid possible abuse)
-Note: When you add the bot or reschedule a meeting, you don't need to "send out invites" for it to work, but you may need to confirm that you trust the bot as it's not in the guardian.co.uk domain.
+2. Paste the URL into your meeting description somewhere, and invite the reminder calendar to your meeting.  Ask John for the calendar ID (it's private to avoid possible abuse)
+Note: When you add the bot or reschedule a meeting, you don't need to "send out invites" for it to work.
 <img width="482" alt="image" src="https://github.com/user-attachments/assets/35a5323a-20c8-46f2-bb4d-c4112f96b64b" />
 
 The bot will drop a message on your channel when the meeting starts, respecting any reschedules or cancellations.
@@ -20,12 +20,14 @@ The bot will drop a message on your channel when the meeting starts, respecting 
 ## Running locally
 
 You should be able to get dev playground aws credentials and then run the main method in the LocalTest class (or type `sbt lambda/run`)
+The lambda will use the SANDBOX calendar when running locally.
+
 Unit tests can be run using `sbt test` (or `sbt cdk/test` and `sbt lambda/test` as required)
 TODO There are no runnable integration tests yet.
 
 ## CODE env
 
-Currently there is only a CODE env and it is the one in use for sending messages.  In future we can add PROD on CD and make CODE (only) send messages to a test channel.
+When running in CODE it will use the SANDBOX calendar as above.  Otherwise it's exactly the same as the PROD one.
 
 ## deploying to code quickly
 

--- a/lambda/src/main/scala/com/gu/meeting/ReminderHandler.scala
+++ b/lambda/src/main/scala/com/gu/meeting/ReminderHandler.scala
@@ -1,30 +1,22 @@
 package com.gu.meeting
 
-import com.google.api.client.googleapis.javanet.GoogleNetHttpTransport
-import com.google.api.client.http.HttpRequestInitializer
-import com.google.api.client.json.gson.GsonFactory
-import com.google.api.services.calendar.{Calendar, CalendarScopes}
-import com.google.auth.http.HttpCredentialsAdapter
-import com.google.auth.oauth2.ServiceAccountCredentials
-import com.gu.conf.{ConfigurationLoader, SSMConfigurationLocation}
 import com.gu.meeting.clients.Config.config
 import com.gu.meeting.clients.GCal.calendar
-import com.gu.{AppIdentity, AwsIdentity, DevIdentity}
-import com.typesafe.config.Config
 import com.typesafe.scalalogging.StrictLogging
-import software.amazon.awssdk.auth.credentials.{AwsCredentialsProviderChain, EnvironmentVariableCredentialsProvider, ProfileCredentialsProvider}
 
-import java.io.ByteArrayInputStream
 import java.net.http.HttpClient
 import java.time.OffsetDateTime
-import scala.jdk.CollectionConverters.*
 
 object LocalTest {
 
-  // this main method is useful to try it locally
+  // this main method is useful to try it locally:
+  // 1. get dev playground read only credentials
+  // 2. add a test meeting to the sandbox calendar
+  // 3. update lambdaWarmStartTime to the time of your test meeting
+  // 4. run this with `sbt lambda/run`
   @main
   def runTest() = {
-    val lambdaWarmStartTime = OffsetDateTime.parse("2025-04-25T09:45:12.123+01:00")
+    val lambdaWarmStartTime = OffsetDateTime.parse("2025-04-29T09:00:12.123+01:00")
     val googleServiceEmail = config.getString("google-service-email")
     ReminderHandlerSteps.runSteps(googleServiceEmail, calendar, lambdaWarmStartTime, HttpClient.newHttpClient)
   }
@@ -35,25 +27,22 @@ object ReminderHandler {
   // reuse static http client
   private val client = HttpClient.newHttpClient
 
-  val lambdaColdStartTime = OffsetDateTime.now() //parse("2025-02-13T12:30:12.123Z")
+  val lambdaColdStartTime = OffsetDateTime.now() // parse("2025-02-13T12:30:12.123Z")
 
 }
 
 class ReminderHandler extends StrictLogging {
 
+  import ReminderHandler.{client, lambdaColdStartTime}
   import com.gu.meeting.clients.Config.*
   import com.gu.meeting.clients.GCal.calendar
-  import ReminderHandler.client
-  import ReminderHandler.lambdaColdStartTime
 
   // main runtime entry point
   def handleRequest(): Unit = {
     // have to watch if the lambda starts around the minute, it might not run exactly once in each minute
-    val lambdaWarmStartTime = OffsetDateTime.now() //parse("2025-02-13T12:30:12.123Z")
+    val lambdaWarmStartTime = OffsetDateTime.now() // parse("2025-02-13T12:30:12.123Z")
     logger.info(s"starting lambda at $lambdaWarmStartTime, cold start was at $lambdaColdStartTime")
     val googleServiceEmail = config.getString("google-service-email")
     ReminderHandlerSteps.runSteps(googleServiceEmail, calendar, lambdaWarmStartTime, client)
   }
 }
-
-

--- a/lambda/src/test/scala/com/gu/meeting/MeetingDataTest.scala
+++ b/lambda/src/test/scala/com/gu/meeting/MeetingDataTest.scala
@@ -3,7 +3,7 @@ package com.gu.meeting
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers
 
-import java.time.{OffsetDateTime, ZoneOffset}
+import java.time.{Instant, LocalDateTime, ZoneId}
 
 class MeetingDataTest extends AnyFlatSpec with Matchers {
   import TestData.*
@@ -14,7 +14,7 @@ class MeetingDataTest extends AnyFlatSpec with Matchers {
       "My Test meeting is starting at 1:00 pm",
       "My Test meeting is starting at 1:00 pm",
     )
-    val actual = testData.maybeMessage(thisMinute)
+    val actual = testData.maybeMessage(thisInstant)
     actual should be(Some(expected))
   }
 
@@ -24,19 +24,19 @@ class MeetingDataTest extends AnyFlatSpec with Matchers {
       "<https://meet.google.com/asd-qwer-zxc|My Test meeting> is starting at 1:00 pm",
       "My Test meeting is starting at 1:00 pm",
     )
-    val actual = testData.maybeMessage(thisMinute)
+    val actual = testData.maybeMessage(thisInstant)
     actual should be(Some(expected))
   }
 
   it should "send no message where the meeting is in one minute" in {
     val testData = thisMinuteNoMeet
-    val actual = testData.maybeMessage(thisMinute.minusSeconds(60))
+    val actual = testData.maybeMessage(thisInstant.minusSeconds(60))
     actual should be(None)
   }
 
   it should "filter out non organisation meetings" in {
     val testData = thisMinuteNoMeet.copy(owner = Some("test@baddies.com"))
-    val actual = testData.maybeMessage(thisMinute)
+    val actual = testData.maybeMessage(thisInstant)
     actual should be(None)
   }
 
@@ -44,11 +44,12 @@ class MeetingDataTest extends AnyFlatSpec with Matchers {
 
 object TestData {
 
-  val thisMinute = OffsetDateTime.of(2025, 4, 23, 12, 0, 0, 0, ZoneOffset.UTC).toInstant
+  private val localDateTime: LocalDateTime = LocalDateTime.of(2025, 4, 23, 13, 0, 0, 0)
+  val thisInstant: Instant = localDateTime.toInstant(ZoneId.of("Europe/London").getRules.getOffset(localDateTime))
 
-  val thisMinuteNoMeet = MeetingData(
+  val thisMinuteNoMeet: MeetingData = MeetingData(
     Some("qwerty https://chat.googleapis.com/asdfghjk zxcvbn"),
-    thisMinute,
+    thisInstant,
     None,
     "My Test meeting",
     Some("hello@guardian.co.uk"),


### PR DESCRIPTION
This PR updates it so only guardian addresses can trigger the bot.  This will reduce the risk of abuse, as it's not necessary for people outside the guardian to trigger web hooks.

I've also done some refactoring to separate the API code from the business logic, which in turn simplified the tests.

And finally I updated the documentation to reflect the fact that we have a proper calendar for SANDBOX and PROD so we can have two deployments.