### PR TITLE
correct S3 key name for artifact

### DIFF
--- a/cdk/src/main/scala/com/gu/meeting/Infra.scala
+++ b/cdk/src/main/scala/com/gu/meeting/Infra.scala
@@ -46,7 +46,7 @@ class InfraStack(scope: Construct, id: String, stage: String, props: StackProps)
     .runtime(Runtime.JAVA_21)
     .memorySize(1024) // MB
     .handler(lambdaClass.getName + "::" + handlerMethod)
-    .code(Code.fromBucketV2(bucket, List(stage, app, app + ".jar").mkString("/"), options))
+    .code(Code.fromBucketV2(bucket, List(stack, stage, app, app + ".jar").mkString("/"), options))
     .timeout(Duration.minutes(1))
     .architecture(Architecture.ARM_64)
     .logGroup(myLogGroup)


### PR DESCRIPTION
It couldn't deploy in PROD because the artifact didn't exist.
In CODE it only existed from a manual copy, and updateLambda was switching it over to the right one.  But the CFN should use the right one in the first place.