### PR TITLE
change back to old way of doing log group retention

### DIFF
--- a/cdk/src/main/scala/com/gu/meeting/Infra.scala
+++ b/cdk/src/main/scala/com/gu/meeting/Infra.scala
@@ -34,6 +34,12 @@ class InfraStack(scope: Construct, id: String, stage: String, props: StackProps)
   val bucket = Bucket.fromBucketName(this, app + "-bucket", bucketName)
   val options: BucketOptions = BucketOptions.builder().build()
 
+  val myLogGroup = LogGroup.Builder
+    .create(this, "MyLogGroupWithLogGroupName")
+    .logGroupName("/aws/lambda/" + id)
+    .retention(RetentionDays.TWO_WEEKS)
+    .build
+
   val fn = Function.Builder
     .create(this, app)
     .functionName(app + "-" + stage)
@@ -43,6 +49,7 @@ class InfraStack(scope: Construct, id: String, stage: String, props: StackProps)
     .code(Code.fromBucketV2(bucket, List(stack, stage, app, app + ".jar").mkString("/"), options))
     .timeout(Duration.minutes(1))
     .architecture(Architecture.ARM_64)
+    .logGroup(myLogGroup)
     .environment(
       Map(
         "App" -> app,
@@ -50,8 +57,9 @@ class InfraStack(scope: Construct, id: String, stage: String, props: StackProps)
         "Stage" -> stage,
       ).asJava,
     )
-    .logRetention(RetentionDays.TWO_WEEKS)
     .build()
+
+  fn.getNode.addDependency(myLogGroup)
 
   val rule = Rule.Builder.create(this, "Schedule Rule").schedule(Schedule.rate(Duration.minutes(1))).build
   rule.addTarget(new LambdaFunction(fn))


### PR DESCRIPTION
After changing the lambda to use the CDK logGroupRetention expression, I found I was getting deploy errors where the lambda code couldn't be found for `LogRetentionaae......lotsofchars....C8A`
I realised this was a magical lambda that CDK makes to enforce the retention, rather than being a proper CFN thing.

In the end I decided to switch back to the old way rather than debugging CDK's internals.