### PR TITLE
add upcoming meetings list to each notification

### DIFF
--- a/lambda/src/main/scala/com/gu/meeting/ChatMessage.scala
+++ b/lambda/src/main/scala/com/gu/meeting/ChatMessage.scala
@@ -1,0 +1,70 @@
+package com.gu.meeting
+
+import com.gu.meeting.ChatMessage.logger
+import com.typesafe.scalalogging.StrictLogging
+import io.circe.Encoder
+
+import java.time.OffsetDateTime
+
+object ChatMessage extends StrictLogging {
+
+  def chatMessagesForEvents(
+      events: List[MeetingData],
+      minuteOfInterest: OffsetDateTime,
+  ): List[(String, ChatMessage)] =
+    groupAndFilterAllEvents(events, minuteOfInterest).flatMap(chatMessage)
+
+  def groupAndFilterAllEvents(
+      events: List[MeetingData],
+      minuteOfInterest: OffsetDateTime,
+  ): List[List[MeetingData]] = {
+    val instantOfInterest = minuteOfInterest.toInstant
+    val endOfDay = minuteOfInterest.withHour(0).plusDays(1).toInstant
+    val eventsByCalendar =
+      events
+        .filter(_.creator.exists(_.endsWith("@guardian.co.uk")))
+        .groupBy(_.organiser.map(_._1))
+    val upcomingMeetingsByCalendar = eventsByCalendar.view
+      .collect { case Some(organiser) -> meetings =>
+        val upcomingMeetings =
+          meetings
+            .dropWhile(_.start.isBefore(instantOfInterest))
+            .takeWhile(_.start.isBefore(endOfDay))
+        organiser -> upcomingMeetings
+      }
+    upcomingMeetingsByCalendar.collect {
+      case _ -> (nextMeetings @ nextMeeting :: _) if nextMeeting.start == instantOfInterest =>
+        logger.info("Sending message for meetings\n  " + nextMeetings.mkString("\n  "))
+        nextMeetings
+    }.toList
+  }
+
+  def chatMessage(upcomingMeetings: List[MeetingData]): Option[(String, ChatMessage)] =
+    upcomingMeetings match {
+      case currentMeeting :: laterMeetings =>
+        import currentMeeting.*
+        val link = meetLink match {
+          case Some(value) => s"<$value|$title>"
+          case None => title
+        }
+        val suffix = s" is starting at " + formattedStart
+        val message = link + suffix
+        val calendarName = currentMeeting.organiser.map(_._2).get // we know it's got a value, fix properly later
+        val formattedLines = List(
+          message,
+        ) ++ (if (laterMeetings.nonEmpty)
+                List(
+                  "",
+                  s"*Later $calendarName meetings today*",
+                )
+              else List()) ++ laterMeetings.map { laterMeeting =>
+          s"${laterMeeting.formattedStart} - ${laterMeeting.title}"
+        }
+        maybeWebHookUrl.map(_ -> ChatMessage(formattedLines.mkString("\n")))
+    }
+
+}
+
+case class ChatMessage(
+    text: String,
+) derives Encoder

--- a/lambda/src/main/scala/com/gu/meeting/MeetingData.scala
+++ b/lambda/src/main/scala/com/gu/meeting/MeetingData.scala
@@ -1,0 +1,61 @@
+package com.gu.meeting
+
+import com.google.api.services.calendar.model.Event
+import com.gu.meeting.MeetingData.{logger, trustedChatBaseUrl}
+import com.typesafe.scalalogging.{LazyLogging, StrictLogging}
+
+import java.time.format.DateTimeFormatter
+import java.time.{Instant, OffsetDateTime, ZoneId}
+import java.util.Locale
+import scala.jdk.CollectionConverters.*
+import scala.util.Try
+
+object MeetingData extends StrictLogging {
+
+  val trustedChatBaseUrl = "https://chat.googleapis.com/" // avoid regex chars.
+
+  def fromApiEvent(event: Event): Option[MeetingData] = {
+    val organiser = Option(event.getOrganizer).flatMap(organizer =>
+      Option(organizer.getEmail).flatMap(email => Option(email -> organizer.getDisplayName)),
+    )
+    logger.info(">>  meeting organised by " + organiser)
+    val creator = Option(event.getCreator).flatMap(c => Option(c.getEmail))
+    logger.info(">>  meeting created by " + creator)
+    val start = Option(event.getStart.getDateTime).getOrElse(event.getStart.getDate)
+    val offsetDateTime = Try(OffsetDateTime.parse(start.toStringRfc3339))
+    logger.info(s">>  summary: ${event.getSummary} ($start / $offsetDateTime)")
+    val maybeDescription = Option(event.getDescription)
+    logger.info(">>  description: " + maybeDescription)
+    val meetLink = Option(event.getHangoutLink)
+    logger.info(">>  meet: " + meetLink)
+    val title = Option(event.getSummary).getOrElse("unnamed meeting")
+    for {
+      time <- offsetDateTime.toOption.map(_.toInstant)
+    } yield MeetingData(maybeDescription, time, meetLink, title, creator, organiser)
+  }
+}
+
+case class MeetingData(
+    description: Option[String],
+    start: Instant,
+    meetLink: Option[String],
+    title: String,
+    creator: Option[String],
+    organiser: Option[(String, String)],
+) extends LazyLogging {
+
+  val formattedStart: String = OffsetDateTime
+    .ofInstant(start, ZoneId.of("Europe/London"))
+    .format(DateTimeFormatter.ofPattern("h:mm a", Locale.UK))
+
+  val maybeWebHookUrl: Option[String] = for {
+    d <- description
+    chatUrl <- d.split(trustedChatBaseUrl).toList match {
+      case _ :: link :: _ => Some(trustedChatBaseUrl + link.takeWhile(!List('"', '<', ' ', '\n').contains(_)))
+      case _ => None
+    }
+    webHookUrl = chatUrl.replaceAll("&amp;", "&")
+    _ = logger.info(">>  chatUrl: " + webHookUrl)
+  } yield webHookUrl
+
+}

--- a/lambda/src/main/scala/com/gu/meeting/ReminderHandler.scala
+++ b/lambda/src/main/scala/com/gu/meeting/ReminderHandler.scala
@@ -15,8 +15,8 @@ object LocalTest {
   // 3. update lambdaWarmStartTime to the time of your test meeting
   // 4. run this with `sbt lambda/run`
   @main
-  def runTest() = {
-    val lambdaWarmStartTime = OffsetDateTime.parse("2025-04-29T09:00:12.123+01:00")
+  def runTest(): Unit = {
+    val lambdaWarmStartTime = OffsetDateTime.parse("2025-05-07T09:00:12.123+01:00")
     val googleServiceEmail = config.getString("google-service-email")
     ReminderHandlerSteps.runSteps(googleServiceEmail, calendar, lambdaWarmStartTime, HttpClient.newHttpClient)
   }
@@ -27,7 +27,7 @@ object ReminderHandler {
   // reuse static http client
   private val client = HttpClient.newHttpClient
 
-  val lambdaColdStartTime = OffsetDateTime.now() // parse("2025-02-13T12:30:12.123Z")
+  val lambdaColdStartTime: OffsetDateTime = OffsetDateTime.now() // parse("2025-02-13T12:30:12.123Z")
 
 }
 

--- a/lambda/src/main/scala/com/gu/meeting/ReminderHandlerSteps.scala
+++ b/lambda/src/main/scala/com/gu/meeting/ReminderHandlerSteps.scala
@@ -4,6 +4,7 @@ import com.google.api.client.util.DateTime as GDateTime
 import com.google.api.services.calendar.Calendar
 import com.google.api.services.calendar.model.{Event, Events}
 import com.gu.meeting.MeetingData.trustedChatBaseUrl
+import com.gu.meeting.ChatMessage.chatMessagesForEvents
 import com.typesafe.scalalogging.{LazyLogging, StrictLogging}
 import io.circe.Encoder
 import io.circe.syntax.*
@@ -21,23 +22,22 @@ object ReminderHandlerSteps extends StrictLogging {
 
     logger.info(s"Getting events from calendar $googleServiceEmail")
 
-    val events: Events = {
-      calendar.events
-        .list(googleServiceEmail)
-        .setMaxResults(10)
-        .setTimeMin(new GDateTime(now.toEpochSecond * 1000))
-        .setOrderBy("startTime")
-        .setSingleEvents(true)
-        .setTimeZone("Europe/London")
-        .execute
+    val events: List[MeetingData] =
+      MeetingList.fromEvents(
+        calendar.events
+          .list(googleServiceEmail)
+          .setMaxResults(20)
+          .setTimeMin(new GDateTime(now.toEpochSecond * 1000))
+          .setOrderBy("startTime")
+          .setSingleEvents(true)
+          .setTimeZone("Europe/London")
+          .execute,
+      )
 
-    }
-
-    val minuteOfInterest = now.withSecond(0).withNano(0).toInstant
+    val minuteOfInterest = now.withSecond(0).withNano(0)
 
     for {
-      meeting <- MeetingList.fromEvents(events)
-      (webHookUrl, chatMessage) <- meeting.maybeMessage(minuteOfInterest)
+      (webHookUrl, chatMessage) <- chatMessagesForEvents(events, minuteOfInterest)
     } {
       val request = HttpRequest
         .newBuilder(URI.create(webHookUrl))
@@ -60,72 +60,5 @@ object MeetingList extends LazyLogging {
       _ = logger.info("got event " + event.getSummary)
       meeting <- MeetingData.fromApiEvent(event)
     } yield meeting
-  }
-}
-
-case class ChatMessage(
-    text: String,
-    formattedText: String,
-) derives Encoder
-
-case class MeetingData(
-    description: Option[String],
-    start: Instant,
-    meetLink: Option[String],
-    title: String,
-    owner: Option[String],
-) extends LazyLogging {
-
-  val chatMessage: ChatMessage = {
-    val link = meetLink match {
-      case Some(value) => s"<$value|$title>"
-      case None => title
-    }
-    val suffix = s" is starting at " + OffsetDateTime
-      .ofInstant(start, ZoneId.of("Europe/London"))
-      .format(DateTimeFormatter.ofPattern("h:mm a", Locale.UK))
-    val message = link + suffix
-    val formattedText = title + suffix
-    ChatMessage(message, formattedText)
-  }
-
-  val maybeWebHookUrl: Option[String] = for {
-    d <- description
-    chatUrl <- d.split(trustedChatBaseUrl).toList match {
-      case _ :: link :: _ => Some(trustedChatBaseUrl + link.takeWhile(!List('"', '<', ' ', '\n').contains(_)))
-      case _ => None
-    }
-    webHookUrl = chatUrl.replaceAll("&amp;", "&")
-    _ = logger.info(">>  chatUrl: " + webHookUrl)
-  } yield webHookUrl
-
-  def maybeMessage(minuteOfInterest: Instant): Option[(String, ChatMessage)] =
-    for {
-      webHookUrl <- maybeWebHookUrl
-      if owner.exists(_.endsWith("@guardian.co.uk"))
-      _ = logger.info(s"comparing minute of interest $minuteOfInterest with $start")
-      if minuteOfInterest == start
-      _ = logger.info("Sending message for meeting " + this)
-    } yield webHookUrl -> chatMessage
-}
-
-object MeetingData extends StrictLogging {
-
-  val trustedChatBaseUrl = "https://chat.googleapis.com/" // avoid regex chars.
-
-  def fromApiEvent(event: Event): Option[MeetingData] = {
-    val owner = Option(event.getCreator.getEmail)
-    logger.info(">>  meeting owned by " + owner)
-    val start = Option(event.getStart.getDateTime).getOrElse(event.getStart.getDate)
-    val offsetDateTime = Try(OffsetDateTime.parse(start.toStringRfc3339))
-    logger.info(s">>  summary: ${event.getSummary} ($start / $offsetDateTime)")
-    val maybeDescription = Option(event.getDescription)
-    logger.info(">>  description: " + maybeDescription)
-    val meetLink = Option(event.getHangoutLink)
-    logger.info(">>  meet: " + meetLink)
-    val title = Option(event.getSummary).getOrElse("unnamed meeting")
-    for {
-      time <- offsetDateTime.toOption.map(_.toInstant)
-    } yield MeetingData(maybeDescription, time, meetLink, title, owner)
   }
 }

--- a/lambda/src/test/scala/com/gu/meeting/ChatMessageTest.scala
+++ b/lambda/src/test/scala/com/gu/meeting/ChatMessageTest.scala
@@ -1,0 +1,76 @@
+package com.gu.meeting
+
+import com.gu.meeting.ChatMessage.*
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
+
+class ChatMessageTest extends AnyFlatSpec with Matchers {
+
+  import TestData.*
+
+  "chatMessage" should "send a message where the meeting HAS NO meet link" in {
+    val testData = thisMinuteNoMeet
+    val expected = "https://chat.googleapis.com/asdfghjk" -> ChatMessage(
+      "My Test meeting is starting at 1:00 pm",
+    )
+    val actual = chatMessage(List(testData))
+    actual should be(Some(expected))
+  }
+
+  it should "send a message where the meeting HAS A meet link" in {
+    val testData = thisMinuteWithMeet
+    val expected = "https://chat.googleapis.com/asdfghjk" -> ChatMessage(
+      "<https://meet.google.com/asd-qwer-zxc|My Test meeting> is starting at 1:00 pm",
+    )
+    val actual = chatMessage(List(testData))
+    actual should be(Some(expected))
+  }
+
+  it should "send a message with multiple upcoming meetings" in {
+    val testData = List(thisMinuteWithMeet, thisMinuteNoMeet.copy(start = thisMinuteNoMeet.start.plusSeconds(60 * 60)))
+    val expected = "https://chat.googleapis.com/asdfghjk" -> ChatMessage(
+      """<https://meet.google.com/asd-qwer-zxc|My Test meeting> is starting at 1:00 pm
+        |
+        |*Later SR: Value meetings today*
+        |2:00 pm - My Test meeting""".stripMargin,
+    )
+    val actual = chatMessage(testData)
+    actual should be(Some(expected))
+  }
+
+  "groupAndFilterAllEvents" should "send a message where the meeting is now" in {
+    val testData = thisMinuteNoMeet
+    val actual = groupAndFilterAllEvents(List(testData), offsetNow)
+    actual should be(List(List(thisMinuteNoMeet)))
+  }
+
+  it should "send no message where the meeting is in one minute" in {
+    val testData = thisMinuteNoMeet
+    val actual = groupAndFilterAllEvents(List(testData), offsetNow.minusSeconds(60))
+    actual should be(List.empty)
+  }
+
+  it should "aggregate meetings with the same calendar" in {
+    val inAnHour = thisMinuteNoMeet.copy(title = "later meeting", start = thisMinuteNoMeet.start.plusSeconds(60 * 60))
+    val testData = List(thisMinuteNoMeet, inAnHour)
+    val actual = groupAndFilterAllEvents(testData, offsetNow)
+    actual should be(List(List(thisMinuteNoMeet, inAnHour)))
+  }
+
+  it should "not aggregate meetings earlier or tomorrow" in {
+    val anHourAgo =
+      thisMinuteNoMeet.copy(title = "earlier meeting", start = thisMinuteNoMeet.start.minusSeconds(60 * 60))
+    val tomorrowMeeting =
+      thisMinuteNoMeet.copy(title = "tomorrow meeting", start = thisMinuteNoMeet.start.plusSeconds(60 * 60 * 24))
+    val testData = List(anHourAgo, thisMinuteNoMeet, tomorrowMeeting)
+    val actual = groupAndFilterAllEvents(testData, offsetNow)
+    actual should be(List(List(thisMinuteNoMeet)))
+  }
+
+  it should "filter out non organisation meetings" in {
+    val testData = thisMinuteNoMeet.copy(creator = Some("test@baddies.com"))
+    val actual = groupAndFilterAllEvents(List(testData), offsetNow)
+    actual should be(List.empty)
+  }
+
+}

--- a/lambda/src/test/scala/com/gu/meeting/MeetingDataTest.scala
+++ b/lambda/src/test/scala/com/gu/meeting/MeetingDataTest.scala
@@ -3,56 +3,44 @@ package com.gu.meeting
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers
 
-import java.time.{Instant, LocalDateTime, ZoneId}
+import java.time.{Instant, LocalDateTime, OffsetDateTime, ZoneId, ZoneOffset}
+import ChatMessage.*
+import com.gu.meeting.TestData.localDateTime
 
 class MeetingDataTest extends AnyFlatSpec with Matchers {
+
   import TestData.*
 
-  "eventsToMessages" should "send a message where the meeting HAS NO meet link" in {
-    val testData = thisMinuteNoMeet
-    val expected = "https://chat.googleapis.com/asdfghjk" -> ChatMessage(
-      "My Test meeting is starting at 1:00 pm",
-      "My Test meeting is starting at 1:00 pm",
-    )
-    val actual = testData.maybeMessage(thisInstant)
-    actual should be(Some(expected))
+  "formattedStart" should "display the time correctly whether it's BST or GMT" in {
+    thisMinuteNoMeet.formattedStart should be("1:00 pm")
+    val time = LocalDateTime.of(2025, 1, 1, 13, 0, 0, 0)
+    val localDateTime: Instant = time.toInstant(ZoneId.of("Europe/London").getRules.getOffset(time)) // in GMT
+    thisMinuteNoMeet.copy(start = localDateTime).formattedStart should be("1:00 pm")
   }
 
-  it should "send a message where the meeting HAS A meet link" in {
-    val testData = thisMinuteNoMeet.copy(meetLink = Some("https://meet.google.com/asd-qwer-zxc"))
-    val expected = "https://chat.googleapis.com/asdfghjk" -> ChatMessage(
-      "<https://meet.google.com/asd-qwer-zxc|My Test meeting> is starting at 1:00 pm",
-      "My Test meeting is starting at 1:00 pm",
-    )
-    val actual = testData.maybeMessage(thisInstant)
-    actual should be(Some(expected))
-  }
-
-  it should "send no message where the meeting is in one minute" in {
-    val testData = thisMinuteNoMeet
-    val actual = testData.maybeMessage(thisInstant.minusSeconds(60))
-    actual should be(None)
-  }
-
-  it should "filter out non organisation meetings" in {
-    val testData = thisMinuteNoMeet.copy(owner = Some("test@baddies.com"))
-    val actual = testData.maybeMessage(thisInstant)
-    actual should be(None)
+  "maybeWebHookUrl" should "only have a value if there's an embedded link in the description" in {
+    thisMinuteNoMeet.maybeWebHookUrl should be(Some("https://chat.googleapis.com/asdfghjk"))
+    thisMinuteWithMeet.copy(description = None).maybeWebHookUrl should be(None)
+    thisMinuteWithMeet.copy(description = Some("kjhaskjdh")).maybeWebHookUrl should be(None)
   }
 
 }
 
 object TestData {
 
-  private val localDateTime: LocalDateTime = LocalDateTime.of(2025, 4, 23, 13, 0, 0, 0)
-  val thisInstant: Instant = localDateTime.toInstant(ZoneId.of("Europe/London").getRules.getOffset(localDateTime))
+  private val localDateTime: LocalDateTime = LocalDateTime.of(2025, 4, 23, 13, 0, 0, 0) // in BST
+  private val londonOffset: ZoneOffset = ZoneId.of("Europe/London").getRules.getOffset(localDateTime)
+  val offsetNow: OffsetDateTime = OffsetDateTime.of(localDateTime, londonOffset)
+  val thisInstant: Instant = localDateTime.toInstant(londonOffset)
 
   val thisMinuteNoMeet: MeetingData = MeetingData(
-    Some("qwerty https://chat.googleapis.com/asdfghjk zxcvbn"),
-    thisInstant,
-    None,
-    "My Test meeting",
-    Some("hello@guardian.co.uk"),
+    description = Some("qwerty https://chat.googleapis.com/asdfghjk zxcvbn"),
+    start = thisInstant,
+    meetLink = None,
+    title = "My Test meeting",
+    creator = Some("hello@guardian.co.uk"),
+    organiser = Some("srvalue@calendar.google.com" -> "SR: Value"),
   )
+  val thisMinuteWithMeet: MeetingData = thisMinuteNoMeet.copy(meetLink = Some("https://meet.google.com/asd-qwer-zxc"))
 
 }


### PR DESCRIPTION
The current messages include the meeting that's starting, and a meet link for it.

This PR updates it so that each message includes an agenda for the rest of the day for that calendar.

before:
<img width="347" alt="image" src="https://github.com/user-attachments/assets/722dce2e-dfc7-461d-95de-267ce52595e0" />
after
<img width="365" alt="image" src="https://github.com/user-attachments/assets/acc16dde-850c-46df-9d20-a1fa481955f1" />
