### PR TITLE
move lambda to membership account

### DIFF
--- a/.github/workflows/ci-scala.yml
+++ b/.github/workflows/ci-scala.yml
@@ -45,7 +45,7 @@ jobs:
         with:
           githubToken: ${{ secrets.GITHUB_TOKEN }}
           roleArn: ${{ secrets.GU_RIFF_RAFF_ROLE_ARN }}
-          projectName: playground::meeting-reminder-bot
+          projectName: support::meeting-reminder-bot
           configPath: ./riff-raff.yaml
           commentingEnabled: 'false'
           contentDirectories: |

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ The bot will drop a message on your channel when the meeting starts, respecting 
 
 ## Running locally
 
-You should be able to get dev playground aws credentials and then run the main method in the LocalTest class (or type `sbt lambda/run`)
+You should be able to get membership aws credentials and then run the main method in the LocalTest class (or type `sbt lambda/run`)
 The lambda will use the SANDBOX calendar when running locally.
 
 Unit tests can be run using `sbt test` (or `sbt cdk/test` and `sbt lambda/test` as required)
@@ -35,7 +35,7 @@ TODO make this nicer (this can be made into an sbt command e.g. `sbt deployToCod
 
 ### Lambda Code
 1. sbt lambda/assembly
-1. aws s3 cp lambda/target/scala-3.6.4/meeting-reminder-bot.jar s3://developer-playground-dist/CODE/meeting-reminder-bot/meeting-reminder-bot.jar --profile developerPlayground
+1. aws s3 cp lambda/target/scala-3.6.4/meeting-reminder-bot.jar s3://membership-dist/CODE/meeting-reminder-bot/meeting-reminder-bot.jar --profile developerPlayground
 1. Go to the lambda console and update the lambda code.
 
 ### Infra/CDK

--- a/cdk/src/main/scala/com/gu/meeting/Infra.scala
+++ b/cdk/src/main/scala/com/gu/meeting/Infra.scala
@@ -14,9 +14,9 @@ import scala.jdk.CollectionConverters.*
 
 object InfraStack {
 
-  val bucketName = "developer-playground-dist"
+  val bucketName = "membership-dist"
   val app = "meeting-reminder-bot"
-  val stack = "playground"
+  val stack = "support"
 
   private val lambdaClass: Class[ReminderHandler] = classOf[ReminderHandler]
 

--- a/lambda/src/main/scala/com/gu/meeting/ReminderHandler.scala
+++ b/lambda/src/main/scala/com/gu/meeting/ReminderHandler.scala
@@ -10,7 +10,7 @@ import java.time.OffsetDateTime
 object LocalTest {
 
   // this main method is useful to try it locally:
-  // 1. get dev playground read only credentials
+  // 1. get membership read only credentials
   // 2. add a test meeting to the sandbox calendar
   // 3. update lambdaWarmStartTime to the time of your test meeting
   // 4. run this with `sbt lambda/run`

--- a/lambda/src/main/scala/com/gu/meeting/clients/Config.scala
+++ b/lambda/src/main/scala/com/gu/meeting/clients/Config.scala
@@ -14,7 +14,7 @@ object Config extends StrictLogging {
 
   private val region = "eu-west-1"
 
-  private val ProfileName = "developerPlayground"
+  private val ProfileName = "membership"
 
   private lazy val credentialsProvider =
     AwsCredentialsProviderChain
@@ -35,7 +35,7 @@ object Config extends StrictLogging {
         AppIdentity.whoAmI(defaultAppName = "meeting-reminder-bot", credentialsProvider).get // throw if failed
     val config = ConfigurationLoader.load(identity, credentialsProvider) {
       case identity: AwsIdentity => SSMConfigurationLocation.default(identity)
-      case DevIdentity(myApp) => SSMConfigurationLocation(s"/CODE/playground/$myApp", region)
+      case DevIdentity(myApp) => SSMConfigurationLocation(s"/CODE/support/$myApp", region)
     }
     logger.info("loaded config")
     config

--- a/riff-raff.yaml
+++ b/riff-raff.yaml
@@ -1,5 +1,5 @@
 stacks:
-  - playground
+  - support
 regions:
   - eu-west-1
 allowedStages:


### PR DESCRIPTION
The dev playground account isn't designed for longer term projects.  Dept wide things should go in a department wide account, and team things in a team account.

This bot is available to be used department wide however the main users are in supporter revenue (value team).  As such it can be moved to membership account to simplify ownership, and if it becomes more widely used across the department it can be moved again.

This PR moves the meeting reminder bot to the membership account.

I have already copied the SSM parameters accordingly:
OLD:
<img width="1031" height="260" alt="image" src="https://github.com/user-attachments/assets/ecf31cf4-ab52-432f-8e48-b357d6d1f76b" />
new
<img width="1038" height="272" alt="image" src="https://github.com/user-attachments/assets/6d6213d8-0302-43ba-b1cc-e9a1f47f94b0" />


The build is passing but the riff raff upload is failing until https://github.com/guardian/riffraff-platform/pull/561 is merged