### PR TITLE
Remove aws-actions/configure-aws-credentials usage

### DIFF
--- a/.github/workflows/ci-scala.yml
+++ b/.github/workflows/ci-scala.yml
@@ -16,13 +16,6 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
-
-      - name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@v4
-        with:
-          role-to-assume: ${{ secrets.GU_RIFF_RAFF_ROLE_ARN }}
-          aws-region: eu-west-1
-
       - name: install npm
         uses: actions/setup-node@v4
         with:


### PR DESCRIPTION
Removes workflow steps using aws-actions/configure-aws-credentials.

v4 and above of riff raff upload action handles the required credentials internally. These credentials fetches are no longer required. For security purposes, we would prefer not to have unused credentials anywhere.